### PR TITLE
node_modulesを同期しないようにする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,12 @@ services:
     container_name: numeronym-converter
     volumes:
       - ./app:/home/app
+      - node_modules_volume:/home/app/node_modules:delegated
+      - build_volume:/home/app/build:nocopy
     ports:
       - 3000:3000
       - 6006:6006
+
+volumes:
+  node_modules_volume:
+  build_volume:


### PR DESCRIPTION
## 💫 関連Issues

## 💪🏻 変更したこと
- node_modulesをホストとコンテナで同期しないようにする
- https://zenn.dev/tamanugi/articles/6f372d45b85c18

## 👀 確認項目
- 下記コマンドを順番に打ってください
- docker compose down
- docker compose build --no-cache
- docker compose up
- docker compose exec node sh
- yarn storybook

